### PR TITLE
Fix Chapter 1 heading format to enable proper table of contents linking

### DIFF
--- a/The Accidental CTO.md
+++ b/The Accidental CTO.md
@@ -46,7 +46,7 @@
 
 - [Chapter 19: The Accidental CTO](#chapter-19-the-accidental-cto) — 299
 
-# The 3 AM Phone Call
+## **Chapter 1: The 3 AM Phone Call**
 
 ### **Part 1: The Crash**
 


### PR DESCRIPTION
## Problem
The table of contents link for Chapter 1 was not working because the chapter heading format was inconsistent with other chapters.

## Solution
- Changed Chapter 1 heading from `# The 3 AM Phone Call` to `## **Chapter 1: The 3 AM Phone Call**`
- This ensures consistency with the formatting pattern used by all other chapters
- Fixes the table of contents link `[Chapter 1: The 3 AM Phone Call](#chapter-1-the-3-am-phone-call)` to work properly

## Changes Made
- Updated Chapter 1 heading format to match other chapters (double hash with bold formatting and "Chapter X:" prefix)
- No other content was modified

## Testing
- Verified that the table of contents link now properly navigates to Chapter 1
- Confirmed formatting consistency across all chapters